### PR TITLE
Feature cluster customization

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,0 @@
-class HomeController < ApplicationController
-
-  def test
-  end
-
-end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,13 +11,14 @@ class OrganizationsController < ApplicationController
   # GET /organizations/1
   # GET /organizations/1.json
   def show
-    p "in show"
     req_organization_id = params[:id].to_i
-    if current_user.admin? || (current_user.org_admin? && (current_user.organization.id == req_organization_id))
-      # show
-    else
+    unless current_user.admin? || (current_user.org_admin? && (current_user.organization.id == req_organization_id))
       flash.alert = "You must be an administrator to access that section"
-      redirect_to organizations_url current_user.organization.id
+      if user_signed_in? && current_user.organization.present?
+        redirect_to organizations_url current_user.organization.id
+      else
+        redirect_to "/"
+      end
     end
   end
 
@@ -78,7 +79,7 @@ class OrganizationsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def organization_params
-      params.require(:organization).permit(:name, :description)
+      params.require(:organization).permit(:name, :description, :cluster_term_singular, :cluster_term_plural, :ventilator_location_term_singular, :ventilator_location_term_plural)
     end
 
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -79,7 +79,9 @@ class OrganizationsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def organization_params
-      params.require(:organization).permit(:name, :description, :cluster_term_singular, :cluster_term_plural, :ventilator_location_term_singular, :ventilator_location_term_plural)
+      params
+        .require(:organization)
+        .permit(:name, :description, :cluster_term_singular, :cluster_term_plural, :ventilator_location_term_singular, :ventilator_location_term_plural)
     end
 
 end

--- a/app/javascript/src/components/cluster.tsx
+++ b/app/javascript/src/components/cluster.tsx
@@ -131,7 +131,6 @@ class Cluster extends Component<IProps, IState> {
         {
           // Temporarily removing for MVP
           // this.getVentDataMonitorsJsx(split.ventDataMonitors, results)
-          // this.getVentDataMonitorsJsx(split.ventDataMonitors, results)
         }
         {this.getCommErrorsJsx(split.commError, results)}
       </React.Fragment>
@@ -152,8 +151,8 @@ class Cluster extends Component<IProps, IState> {
       let result: IDevicePollResult = results[v.id]
 
       // We only know whether the device at the other end is a data monitor or an alarm
-      // monito based on what it tell us (at least one of the keys in
-      // result.apiResponse.device.roles should be true). So, if we had not had a response
+      // monitor based on what it tells us in a response (at least one of the keys in
+      // result.apiResponse.device.roles should be true). So, if we do not have a response
       // we can't be sure what it is.
 
       if (!result) {
@@ -169,6 +168,8 @@ class Cluster extends Component<IProps, IState> {
         return
       }
 
+      // We have a response ! - What role is the monitor in?
+
       let placed = false
 
       if (result.apiResponse.device.roles.ventilatorAlarmSoundMonitor) {
@@ -181,7 +182,8 @@ class Cluster extends Component<IProps, IState> {
         placed = true
       }
 
-      // we got a response, but neither key was true. This is a schema error.
+      // we got a response, but neither key was true. This is a schema error and should
+      // have resulted in a comm error.
       if (!placed) {
         split.other.push(v)
       }
@@ -195,7 +197,7 @@ class Cluster extends Component<IProps, IState> {
       let result: IDevicePollResult = results[v.id]
       let alert = getFirstAlert(result?.apiResponse?.ventilatorAlarmSoundMonitor?.alerts)
       let reason = this.getAlertText(alert)
-      let statusJsx = this.getStatus(!alert)
+      let statusJsx = this.getStatusJsx(!alert)
       return (
         <tr key={this.getKey(v)}>
             <td>{v.name}</td>
@@ -212,7 +214,7 @@ class Cluster extends Component<IProps, IState> {
           <table className='demo-ventilator-table narrow'>
             <thead>
               <tr className="tr-heading">
-                <th>Unit</th>
+                <th>{this.props.cluster.organization.ventilatorLocationTermSingular}</th>
                 <th>Status</th>
                 <th>Alert</th>
               </tr>
@@ -226,6 +228,7 @@ class Cluster extends Component<IProps, IState> {
     )
   }
 
+  /*
   getVentDataMonitorsJsx = (vents: IVentilator[], results: Results) => {
     return (
       <div className="group">
@@ -236,7 +239,7 @@ class Cluster extends Component<IProps, IState> {
               <table className='demo-ventilator-table'>
                 <thead>
                   <tr className="tr-heading">
-                    <th>Unit</th>
+                    <th>{this.props.cluster.organization.ventilatorLocationTermSingular}</th>
                     <th>Status</th>
                     <th>Tidal Volume </th>
                     <th>Respiratory Rate</th>
@@ -270,6 +273,7 @@ class Cluster extends Component<IProps, IState> {
       </div>
     )
   }
+  */
 
   getCommErrorsJsx = (vents: IVentilator[], results: Results) => {
     if (! vents.length) {
@@ -279,7 +283,7 @@ class Cluster extends Component<IProps, IState> {
       let result: IDevicePollResult = results[v.id]
       let alert = getFirstAlert(result?.apiReceiveStatus?.alerts)
       let reason = this.getAlertText(alert)
-      let statusJsx = this.getStatus(!alert)
+      let statusJsx = this.getStatusJsx(!alert)
       return (
         <tr key={this.getKey(v)}>
             <td>{v.name}</td>
@@ -295,7 +299,7 @@ class Cluster extends Component<IProps, IState> {
         <table className='demo-ventilator-table narrow'>
           <thead>
             <tr className="tr-heading">
-              <th>Unit</th>
+              <th>{this.props.cluster.organization.ventilatorLocationTermSingular}</th>
               <th>Status</th>
               <th>Reason</th>
             </tr>
@@ -314,7 +318,7 @@ class Cluster extends Component<IProps, IState> {
     return `${this.props.cluster.id}-${vent.id}`
   }
 
-  getStatus = (ok: boolean) => {
+  getStatusJsx = (ok: boolean) => {
     return ok
       ? <Circle size="lg" color={'LimeGreen'}/>
       : <ExclamationTriangle size="lg" color={'red'} className="flash"/>

--- a/app/javascript/src/components/cluster.tsx
+++ b/app/javascript/src/components/cluster.tsx
@@ -2,7 +2,6 @@ import React, { Component } from "react"
 import { ICluster, IVentilator, IDevicePollResult } from '../types'
 import { DevicePoller } from '../poller/devicePoller'
 import { SimulatedDevicePoller } from '../poller/simulatedDevicePoller'
-import Ventilator from './ventilator'
 import { BaseDevicePoller } from "../poller/baseDevicePoller"
 import {ExclamationTriangle, Circle} from './icons'
 import { getFirstAlert, camelCaseToWords } from "../utils"
@@ -117,7 +116,7 @@ class Cluster extends Component<IProps, IState> {
       return (
         <React.Fragment>
           <h4>{cluster.name}</h4>
-          <h6>This cluster has no ventilators.</h6>
+          <h6>{`This ${cluster.organization.clusterTermSingular} has no ventilator monitors.`}</h6>
         </React.Fragment>
       )
     }

--- a/app/javascript/src/components/organization.tsx
+++ b/app/javascript/src/components/organization.tsx
@@ -19,14 +19,14 @@ interface IState {
 
 class Organization extends Component<IProps, IState> {
   options: IOption[]
-  clusterNameKey: string
+  selectedClusterNameKey: string
 
   constructor(props: IProps) {
     super(props)
 
     console.assert(props.organization, "missing organization")
 
-        this.state = {selectedOption: null}
+    this.selectedClusterNameKey = `SelectedClusterName-${props.organization.id}`
 
     // make an array for the select
     this.options = props.organization.clusters.map((cluster) => {
@@ -36,7 +36,7 @@ class Organization extends Component<IProps, IState> {
       }
     })
 
-    this.clusterNameKey = `ClusterName-${props.organization.id}`
+    this.state = {selectedOption: null}
 
     this.setClusterSelection()
   }
@@ -53,10 +53,10 @@ class Organization extends Component<IProps, IState> {
     let selectedClusterIndx = -1
 
     // note: we store the cluster ID (for each specfic org-id), not the index
-    var storedClusterName = localStorage.getItem(this.clusterNameKey)
+    var storedClusterName = localStorage.getItem(this.selectedClusterNameKey)
 
     if (storedClusterName) {
-      selectedClusterIndx = this.options.findIndex((o) => o.label === storedClusterName)
+      selectedClusterIndx = this.options.findIndex((o) => o.label == storedClusterName)
     }
 
     selectedClusterIndx = selectedClusterIndx === -1 ? 0 : selectedClusterIndx
@@ -72,7 +72,7 @@ class Organization extends Component<IProps, IState> {
 
     // update localStorage each time the user selects a new option from the
     // dropdown. When they refresh the page, the same option should be selected for them.
-    localStorage.setItem(this.clusterNameKey, selectedOption.label)
+    localStorage.setItem(this.selectedClusterNameKey, selectedOption.label)
   }
 
   render() {
@@ -87,7 +87,7 @@ class Organization extends Component<IProps, IState> {
       return (
         <section>
           <h3>{organization.name}</h3>
-          <h4>This organization does not have any clusters.</h4>
+          <h4>{`This organization does not have any ${organization.clusterTermPlural}.`}</h4>
         </section>
       )
     }

--- a/app/javascript/src/components/ventilatorTree.tsx
+++ b/app/javascript/src/components/ventilatorTree.tsx
@@ -12,6 +12,10 @@ const VENTILATORS_API_URI = '/api/v1/ventilators'
 let demoOrg: IOrganization = {
   id: 0x7FFFFFFF,
   name: 'DEMO Hospital',
+  clusterTermSingular: 'Wing',
+  clusterTermPlural: 'Wings',
+  ventilatorLocationTermSingular: 'Room',
+  ventilatorLocationTermPlural: 'Rooms',
   clusters: [
     {
       id: 1,
@@ -28,8 +32,12 @@ let demoOrg: IOrganization = {
   ]
 }
 
-// Populate the clusters with 6 ventilators each
-for (let i = 0; i < 6; i ++) {
+// fix-up backpointers from cluster to org
+demoOrg.clusters[0].organization = demoOrg
+demoOrg.clusters[1].organization = demoOrg
+
+// Populate the clusters with ventilator monitors
+for (let i = 1; i < 5; i ++) {
   demoOrg.clusters[0].ventilators.push({id: i, name: `East-${i}`, hostname: 'n/a', apiKey: 'n/a'})
   demoOrg.clusters[1].ventilators.push({id: i, name: `West-${i}`, hostname: 'n/a', apiKey: 'n/a'})
 }
@@ -94,13 +102,18 @@ class VentilatorTree extends Component<IProps, IState> {
       }
     }
 
+    // console.log(`Organization: ${JSON.stringify(organization, null, 2)}`)
+
     let errMsg = success ? null : 'There was an error while getting the Organization information from the server.'
 
     if (success) {
       // sort the cluster names
       sortObjects(organization.clusters, "name")
-      // for each cluster, sort the ventilators
-      organization.clusters.forEach((c) => sortObjects(c.ventilators, "name"))
+      // for each cluster, sort the ventilators, and fix-up a back-pointer to organization
+      organization.clusters.forEach((c) => {
+        c.organization = organization
+        sortObjects(c.ventilators, "name")
+      })
     }
 
     this.setState({

--- a/app/javascript/src/poller/simulatedDevicePoller.ts
+++ b/app/javascript/src/poller/simulatedDevicePoller.ts
@@ -4,7 +4,6 @@ import { BaseDevicePoller } from './baseDevicePoller'
 import cloneDeep from 'lodash.clonedeep'
 
 const VENTILATOR_NAMES_WITH_SIMULATED_COMM_FAILURE = ["East-2", "West-4"]
-const VENTILATOR_NAMES_WITH_VENTILATOR_ALARM_SOUND_MONITORING = ["East-1", "East-4", "West-3"]
 const VENTILATOR_NAMES_WITH_AUDIO_ALARM_ALERT = ["East-4"]
 
 export class SimulatedDevicePoller extends BaseDevicePoller {
@@ -22,6 +21,10 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
 
     let result = this.getFreshPollResultWithPreviousValues()
 
+    // because we are not simulating data monitors, we can skip this.
+    // we are not randomly changing alarm monitors from/to alerted/not alerted
+
+    /*
     // 50% of the time, don't change anything
     let change = generateRandomValueBetween(0, 1)
     if (change === 0) {
@@ -30,6 +33,7 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
 
     // otherwise, get a new status object with the value of one measuement item changed
     this.updateOneMeasurementField(result)
+    */
 
     return Promise.resolve(result)
   }
@@ -52,21 +56,19 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
       }
     }
 
-    if (VENTILATOR_NAMES_WITH_VENTILATOR_ALARM_SOUND_MONITORING.includes(this._device.name)) {
-      result.apiResponse.device.roles.ventilatorAlarmSoundMonitor = true
-    }
-
     if (VENTILATOR_NAMES_WITH_AUDIO_ALARM_ALERT.includes(this._device.name)) {
       result.apiResponse.ventilatorAlarmSoundMonitor.alerts.audioAlarm = true
     }
 
-    let status = result.apiResponse.ventilatorDataMonitor.status
+    if (result.apiResponse['ventilatorDataMonitor']) {
+      let status = result.apiResponse.ventilatorDataMonitor.status
 
-    status.ieRatio.value = this.generateRandomColumnValue('ieRatio')
-    status.peakInspiratoryPressure.value = this.generateRandomColumnValue('peakInspiratoryPressure')
-    status.peep.value = this.generateRandomColumnValue('peep')
-    status.respiratoryRate.value = this.generateRandomColumnValue('respiratoryRate')
-    status.tidalVolume.value = this.generateRandomColumnValue('tidalVolume')
+      status.ieRatio.value = this.generateRandomColumnValue('ieRatio')
+      status.peakInspiratoryPressure.value = this.generateRandomColumnValue('peakInspiratoryPressure')
+      status.peep.value = this.generateRandomColumnValue('peep')
+      status.respiratoryRate.value = this.generateRandomColumnValue('respiratoryRate')
+      status.tidalVolume.value = this.generateRandomColumnValue('tidalVolume')
+    }
 
     return result
   }
@@ -86,6 +88,8 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
   // Get a new response (with fresh timestamps), copy over the measurement from the current state, and then
   // modify one of the measurement items. Pick one at random and pick the direction (+1 / -1) at random.
   // ieRatio is a special case becasue the value is 1:n, so just mack it 1:2 or 1:4
+
+  /*
   updateOneMeasurementField(result: IDevicePollResult) : void {
     let status = result.apiResponse.ventilatorDataMonitor.status
     let columnIndx = generateRandomValueBetween(0, BaseDevicePoller.MeasurementFieldNames.length - 1)
@@ -99,6 +103,7 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
     status[key].value = newValue
     // console.log(`changed ${key} to ${newValue}`)
   }
+  */
 
   /**
    * This is used by SimulatedDevicePoller to initialize the result.
@@ -115,10 +120,11 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
           id: `${this._device.id}-${this._device.name}`,
           currentTime: new Date(),
           roles: {
-            ventilatorAlarmSoundMonitor: false,
-            ventilatorDataMonitor: true
+            ventilatorAlarmSoundMonitor: true,
+            ventilatorDataMonitor: false
           }
         },
+        /*
         ventilatorDataMonitor: {
           timestamp: new Date(),
           status: {
@@ -145,6 +151,7 @@ export class SimulatedDevicePoller extends BaseDevicePoller {
           },
           alerts: {}
         },
+        */
         ventilatorAlarmSoundMonitor: {
             timestamp: new Date(),
             status: {

--- a/app/javascript/src/types.ts
+++ b/app/javascript/src/types.ts
@@ -1,10 +1,15 @@
 export interface IOrganization {
   id: number
   name: string
+  clusterTermSingular: string
+  clusterTermPlural: string
+  ventilatorLocationTermSingular: string
+  ventilatorLocationTermPlural: string
   clusters: ICluster[]
 }
 
 export interface ICluster {
+  organization?: IOrganization
   id: number
   name: string
   ventilators: IVentilator[]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,7 +1,20 @@
 class Organization < ApplicationRecord
+  after_initialize :set_defaults
+
   has_many :users
   has_many :clusters
   has_many :ventilators, through: :clusters
 
   validates :name, length: { minimum: 5 }
+  validates :cluster_term_singular, length: { minimum: 3 }
+  validates :cluster_term_plural, length: { minimum: 3 }
+  validates :ventilator_location_term_singular, length: { minimum: 3 }
+  validates :ventilator_location_term_plural, length: { minimum: 3 }
+
+  def set_defaults
+    self.cluster_term_singular ||= "Floor"
+    self.cluster_term_plural ||= "Floors"
+    self.ventilator_location_term_singular ||= "Room"
+    self.ventilator_location_term_plural ||= "Rooms"
+  end
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -3,6 +3,6 @@ class OrganizationSerializer
   set_key_transform :camel_lower
 
   set_id :id
-  attributes :name
+  attributes :name, :cluster_term_singular, :cluster_term_plural, :ventilator_location_term_singular, :ventilator_location_term_plural
   has_many :clusters
 end

--- a/app/views/clusters/_form.html.erb
+++ b/app/views/clusters/_form.html.erb
@@ -11,14 +11,16 @@
   <% end %>
 
   <table>
-    <col style="width:25%">
+    <colgroup>
+      <col style="width:25%">
+    </colgroup>
     <tr class="field">
       <td>Belongs to organization</td>
       <td>
         <% if current_user.admin? %>
           <%= form.collection_select( :organization_id, Organization.all, :id, :name, {}, { class: "form-control" })  %>
         <% else  %>
-          <input value="<%= current_user.organization.name %>" class="form-control" disabled></input>
+          <input value="<%= current_user.organization.name %>" class="form-control" disabled />
         <% end %>
       </td>
     </tr>
@@ -36,7 +38,7 @@
 
   <section>
     <div class="actions">
-      <%= form.submit class: "btn btn-info"%>
+      <%= form.submit "Update #{cluster.organization.cluster_term_singular}", class: "btn btn-info"%>
     </div>
   </section>
 <% end %>

--- a/app/views/clusters/_form.html.erb
+++ b/app/views/clusters/_form.html.erb
@@ -38,7 +38,7 @@
 
   <section>
     <div class="actions">
-      <%= form.submit "Update #{cluster.organization.cluster_term_singular}", class: "btn btn-info"%>
+      <%= form.submit "Create / Update #{cluster.organization.cluster_term_singular}", class: "btn btn-info"%>
     </div>
   </section>
 <% end %>

--- a/app/views/clusters/_form.html.erb
+++ b/app/views/clusters/_form.html.erb
@@ -38,7 +38,8 @@
 
   <section>
     <div class="actions">
-      <%= form.submit "Create / Update #{cluster.organization.cluster_term_singular}", class: "btn btn-info"%>
+      <% action = cluster.persisted? ? "Update" : "Create" %>
+      <%= form.submit "#{action} #{cluster.organization.cluster_term_singular}", class: "btn btn-info"%>
     </div>
   </section>
 <% end %>

--- a/app/views/clusters/edit.html.erb
+++ b/app/views/clusters/edit.html.erb
@@ -1,17 +1,17 @@
-<h1>Editing Cluster</h1>
+<h1>Editing <%= @cluster.organization.cluster_term_singular %></h1>
 
 <section>
   <%= render 'form', cluster: @cluster %>
 </section>
 
 
-<%= button_to "Delete This Cluster",
+<%= button_to "Delete #{@cluster.organization.cluster_term_singular}",
   {
     controller: :clusters,
     action: 'destroy',
     id: @cluster.id
   },
   method: :delete,
-  data: { confirm: 'Are you sure you want to delete this cluster? This action cannot be undone.' },
+  data: { confirm: "Are you sure you want to delete #{@cluster.name}? This action cannot be undone." },
   class: "btn btn-danger"
 %>

--- a/app/views/clusters/index.html.erb
+++ b/app/views/clusters/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/link_to_org', organization: @organization %>
 
-<h4>Clusters</h4>
+<h4><%= @organization.cluster_term_plural %></h4>
 
 <section>
   <table class="table">

--- a/app/views/clusters/new.html.erb
+++ b/app/views/clusters/new.html.erb
@@ -1,4 +1,4 @@
-<h4>New Cluster</h4>
+<h4>New <%= @cluster.organization.cluster_term_singular %></h4>
 
 <section>
   <%= render 'form', cluster: @cluster %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,7 +1,6 @@
 <%= render 'shared/link_to_org', organization: @organization %>
 
 <h4>
-  <span class="label">Cluster:</span>
   <%= @cluster.name %>
 </h4>
 
@@ -14,19 +13,19 @@
     <a href="<%= edit_cluster_path %>">
       <button class="btn btn-info">
         <i class="fas fa-cog"></i>
-        Cluster Settings
+        <%= @organization.cluster_term_singular %> Settings
       </button>
     </a>
   </section>
 <% end %>
 
 <section>
-  <h4>Ventilators in cluster: <%=@cluster.name %></h4>
+  <h4><%= @cluster.name %></h4>
   <table class="table">
     <col style="width:25%">
     <thead>
       <tr>
-        <th>Name</th>
+        <th><%= @cluster.organization.ventilator_location_term_singular %></th>
         <th>Hostname</th>
       </tr>
     </thead>
@@ -49,7 +48,7 @@
   <section>
     <a href="/ventilators/new?cluster_id=<%= @cluster.id %>">
       <button class="btn btn-info">
-        + Add New Ventilator
+        + Add New Ventilator Monitor
       </button>
     </a>
   </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,0 @@
-<%= javascript_pack_tag 'index' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
         <% if user_signed_in? %>
           <% if current_user.organization %>
             <li class="nav-item">
-                <a class="nav-link" href="/clusters">My Clusters</a>
+                <a class="nav-link" href="/clusters">My <%= current_user.organization.cluster_term_plural %></a>
             </li>
           <% end %>
         <% end %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -23,6 +23,26 @@
         <td><%= form.label :description %></td>
         <td><%= form.text_area :description, size: "30x2" %></td>
       </tr>
+
+      <tr class="field">
+        <td><%= form.label "Cluster term - singular" %></td>
+        <td><%= form.text_field :cluster_term_singular, placeholder: "Floor" %></td>
+      </tr>
+
+      <tr class="field">
+        <td><%= form.label "Cluster term - plural" %></td>
+        <td><%= form.text_field :cluster_term_plural, placeholder: "Floors" %></td>
+      </tr>
+
+      <tr class="field">
+        <td><%= form.label "Ventilator location term - singular" %></td>
+        <td><%= form.text_field :ventilator_location_term_singular, placeholder: "Room/Bed" %></td>
+      </tr>
+
+      <tr class="field">
+        <td><%= form.label "Ventilator location term - plural" %></td>
+        <td><%= form.text_field :ventilator_location_term_plural, placeholder: "Rooms/Beds" %></td>
+      </tr>
     </table>
   </section>
 

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -36,12 +36,12 @@
 
       <tr class="field">
         <td><%= form.label "Ventilator location term - singular" %></td>
-        <td><%= form.text_field :ventilator_location_term_singular, placeholder: "Room/Bed" %></td>
+        <td><%= form.text_field :ventilator_location_term_singular, placeholder: "Room" %></td>
       </tr>
 
       <tr class="field">
         <td><%= form.label "Ventilator location term - plural" %></td>
-        <td><%= form.text_field :ventilator_location_term_plural, placeholder: "Rooms/Beds" %></td>
+        <td><%= form.text_field :ventilator_location_term_plural, placeholder: "Rooms" %></td>
       </tr>
     </table>
   </section>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,5 +1,4 @@
 <h4>
-  <span class="label">Organization:</span>
   <%= @organization.name %>
 </h4>
 
@@ -19,9 +18,11 @@
 </section>
 
 <section>
-  <h4>Clusters in: <%=@organization.name %></h3>
+  <h4><%=@organization.cluster_term_plural%>:</h4>
   <table class="table">
-    <col style="width:25%">
+    <colgroup>
+      <col style="width:25%">
+    </colgroup>
     <thead>
       <tr>
         <th>Name</th>
@@ -45,7 +46,7 @@
   <% if current_user.admin? || current_user.org_admin? && (params[:id].to_i == current_user.organization.id) %>
       <a href="/clusters/new?organization_id=<%= @organization.id %>">
         <button class="btn btn-info">
-          + Add New Cluster
+          + Add New <%= @organization.cluster_term_singular %>
         </button>
       </a>
   <% end %>

--- a/app/views/ventilators/_form.html.erb
+++ b/app/views/ventilators/_form.html.erb
@@ -13,7 +13,7 @@
   <table>
     <col style="width:25%">
     <tr class="field">
-      <td>Belongs to cluster</td>
+      <td>Belongs to <%= ventilator.cluster.organization.cluster_term_singular %></td>
       <td>
         <% if current_user.admin? %>
           <%= form.collection_select( :cluster_id, Cluster.all, :id, :name, {}, { class: "form-control" })  %>
@@ -61,7 +61,7 @@
 
   <section>
       <div class="actions">
-        <%= form.submit class: "btn btn-info"%>
+        <%= form.submit "Create Ventilator Monitor", class: "btn btn-info"%>
       </div>
     </section>
 <% end %>

--- a/app/views/ventilators/_form.html.erb
+++ b/app/views/ventilators/_form.html.erb
@@ -61,7 +61,7 @@
 
   <section>
       <div class="actions">
-        <%= form.submit "Create Ventilator Monitor", class: "btn btn-info"%>
+        <%= form.submit "Create / Update Ventilator Monitor", class: "btn btn-info"%>
       </div>
     </section>
 <% end %>

--- a/app/views/ventilators/_form.html.erb
+++ b/app/views/ventilators/_form.html.erb
@@ -61,7 +61,8 @@
 
   <section>
       <div class="actions">
-        <%= form.submit "Create / Update Ventilator Monitor", class: "btn btn-info"%>
+        <% action = ventilator.persisted? ? "Update" : "Create" %>
+        <%= form.submit "#{action} Ventilator Monitor", class: "btn btn-info"%>
       </div>
     </section>
 <% end %>

--- a/app/views/ventilators/edit.html.erb
+++ b/app/views/ventilators/edit.html.erb
@@ -1,4 +1,4 @@
-<h4>Editing Ventilator</h4>
+<h4>Editing Ventilator Monitor</h4>
 
 <%= render 'shared/link_to_org', organization: @ventilator.cluster.organization %>
 
@@ -6,14 +6,14 @@
   <%= render 'form', ventilator: @ventilator %>
 </section>
 
-<%= button_to "Delete This Ventilator",
+<%= button_to "Delete This Ventilator Monitor",
   {
     controller: :ventilators,
     action: 'destroy',
     id: @ventilator.id
   },
   method: :delete,
-  data: { confirm: 'Are you sure you want to delete this ventilator? This action cannot be undone.' },
+  data: { confirm: "Are you sure you want to delete this ventilator monitor #{@ventilator.name}? This action cannot be undone." },
   class: "btn btn-danger"
 %>
 

--- a/app/views/ventilators/index.html.erb
+++ b/app/views/ventilators/index.html.erb
@@ -5,7 +5,7 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Cluster</th>
+      <th><%= current_user.organization.cluster_term_singular %></th>
       <th>Name</th>
       <th>Hostname</th>
       <th colspan="1"></th>

--- a/app/views/ventilators/new.html.erb
+++ b/app/views/ventilators/new.html.erb
@@ -1,4 +1,4 @@
-<h4>New Ventilator</h4>
+<h4>New Ventilator Monitor</h4>
 
 <%= render 'shared/link_to_org', organization: @organization %>
 

--- a/app/views/ventilators/show.html.erb
+++ b/app/views/ventilators/show.html.erb
@@ -3,7 +3,7 @@
 <%= render 'shared/link_to_cluster', cluster: @ventilator.cluster %>
 
 <h4>
-  Ventilator: <%= @ventilator.name %>
+  Ventilator Monitor: <%= @ventilator.name %>
 </h4>
 
 <section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
   root 'static_pages#index'
 
-  get '/home', to: 'static_pages#index', as: 'home'
   get '/about', to: 'static_pages#about', as: 'about'
   get '/contribute', to: 'static_pages#contribute', as: 'contribute'
 

--- a/db/migrate/20200424153113_add_cluster_terms_to_organization.rb
+++ b/db/migrate/20200424153113_add_cluster_terms_to_organization.rb
@@ -1,4 +1,4 @@
-class AddClusterUiTermToOrganization < ActiveRecord::Migration[6.0]
+class AddClusterTermsToOrganization < ActiveRecord::Migration[6.0]
   def change
     add_column :organizations, :cluster_term_singular, :string
     add_column :organizations, :cluster_term_plural, :string

--- a/db/migrate/20200424153113_add_cluster_ui_term_to_organization.rb
+++ b/db/migrate/20200424153113_add_cluster_ui_term_to_organization.rb
@@ -1,0 +1,6 @@
+class AddClusterUiTermToOrganization < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :cluster_term_singular, :string
+    add_column :organizations, :cluster_term_plural, :string
+  end
+end

--- a/db/migrate/20200424171310_add_ventilator_location_terms_to_organization.rb
+++ b/db/migrate/20200424171310_add_ventilator_location_terms_to_organization.rb
@@ -1,0 +1,6 @@
+class AddVentilatorLocationTermsToOrganization < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :ventilator_location_term_singular, :string
+    add_column :organizations, :ventilator_location_term_plural, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_11_175756) do
+ActiveRecord::Schema.define(version: 2020_04_24_171310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,10 @@ ActiveRecord::Schema.define(version: 2020_04_11_175756) do
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "cluster_term_singular"
+    t.string "cluster_term_plural"
+    t.string "ventilator_location_term_singular"
+    t.string "ventilator_location_term_plural"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,20 +11,18 @@ Cluster.delete_all
 User.delete_all
 Organization.delete_all
 
-org1 = Organization.create( name: "Honnah Lee Medical Center",
-                            description: "Honnah Lee Medical Center",
-                            cluster_term_singular: "Building / Floor",
-                            cluster_term_plural: "Buildings / Floors"
+org1 = Organization.create!( name: "Honnah Lee Medical Center",
+                            description: "Honnah Lee Medical Center Description",
                           )
 
-c1 = org1.clusters.create( name: "Org #1 Cluster #1", description: "Org #1 Cluster #1 Description")
-org1.clusters.create( name: "Org #1 Cluster #2", description: "Org #1 Cluster #2 Description")
-org1.clusters.create( name: "Org #1 Cluster #3", description: "Org #1 Cluster #2 Description")
+c1 = org1.clusters.create!( name: "1st Floor", description: "1st Floor Description")
+org1.clusters.create!( name: "2nd Floor", description: "2nd Floor Description")
+org1.clusters.create!( name: "3rd Floor", description: "3rd Floor Description")
 
 6.times do |i|
-  c1.ventilators.create(
+  c1.ventilators.create!(
     {
-      name: "Ventilator ##{i + 1}",
+      name: "Room #{i + 1}",
       serial_number: "J42#{i + 1}",
       hostname: "ventilator-#{i + 1}.local",
       api_key: "api_key",
@@ -33,9 +31,3 @@ org1.clusters.create( name: "Org #1 Cluster #3", description: "Org #1 Cluster #2
   )
 end
 
-org1.users.create({
-  email: "user1@gmail.com",
-  name: "User 1",
-  encrypted_password: "thisisnotanencryptedpassword",
-  role: 1
-})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,11 @@ Cluster.delete_all
 User.delete_all
 Organization.delete_all
 
-org1 = Organization.create( name: "Org #1", description: "Org #1 Description" )
+org1 = Organization.create( name: "Honnah Lee Medical Center",
+                            description: "Honnah Lee Medical Center",
+                            cluster_term_singular: "Building / Floor",
+                            cluster_term_plural: "Buildings / Floors"
+                          )
 
 c1 = org1.clusters.create( name: "Org #1 Cluster #1", description: "Org #1 Cluster #1 Description")
 org1.clusters.create( name: "Org #1 Cluster #2", description: "Org #1 Cluster #2 Description")


### PR DESCRIPTION
These change enable the org admin to give a name to clusters, such as "Floors" and a name to ventilator monitor locations, such as "Rooms". Those terms are then used in the entire UI -- both Ruby and React -- in place of "cluster" and "ventilator". 